### PR TITLE
Add ticker seed script, /search API, and Docker Compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 # Build: docker build -t stockinfo:latest .
 # Run: docker run -d -p 8000:8000 --name stockinfo-app stockinfo:latest
 
-
 # 1. 베이스 이미지 선택
 FROM python:3.12-slim
 

--- a/app/database.py
+++ b/app/database.py
@@ -5,12 +5,11 @@ from pymongo import MongoClient
 from pymongo.server_api import ServerApi
 
 load_dotenv()
-
 db_password = os.getenv("DB_PASSWORD")
 if not db_password:
     raise ValueError("DB_PASSWORD is not set in .env")
 
-uri = f"mongodb+srv://skkucapstone:{db_password}@stock.iz5b97b.mongodb.net/?appName=stock"
+uri = f"mongodb+srv://skkucapstone:{db_password}@stock.iz5b97b.mongodb.net/?"
 
 client = MongoClient(uri, server_api=ServerApi('1'))
 
@@ -21,4 +20,3 @@ except Exception as e:
     print("Failed to connect MongoDB:", e)
 
 db = client["db"]
-stock_collection = db["stocks"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,16 @@
 # app/main.py
 from fastapi import FastAPI
-from .routers import stock
+from .routers import stock, search
 
 app = FastAPI()
 
-app.include_router(stock.router)
+app.include_router(stock.router)    # /stock-info
+app.include_router(search.router)   # /search 자동완성 API 추가
 
 @app.get("/")
 def read_root():
     return {
         "message": "Welcome to the Stock Prediction API",
         "status": "running",
-        "endpoints": ["/stock-info"]
+        "endpoints": ["/stock-info", "/search"]
     }

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,0 +1,19 @@
+# app/routers/search.py
+from fastapi import APIRouter, Query
+from ..database import db
+
+router = APIRouter()
+
+# GET /search?t=XXX
+@router.get("/search")
+def search_tickers(t: str = Query(..., description="검색 키워드")):
+    """
+    종목 코드(ticker) 또는 회사 이름(name)으로 자동완성 검색
+    - Query param: t
+    """
+    regex = {"$regex": t, "$options": "i"}
+    results = db["tickers"].find(
+        { "$or": [ { "ticker": regex }, { "name": regex } ] },
+        { "_id": 0 }
+    ).limit(10)
+    return list(results)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  backend:
+    build: .
+    image: stockinfo:latest
+    container_name: stockinfo-backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      - DB_PASSWORD=${DB_PASSWORD}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn==0.24.0.post1
 pydantic==2.5.2
 python-dotenv==1.0.0
 pymongo==4.11.3 
+yfinance==0.2.55
+lxml==5.3.2

--- a/scripts/seed_us_stocks.py
+++ b/scripts/seed_us_stocks.py
@@ -1,0 +1,60 @@
+# scripts/seed_sp500_tickers.py
+import yfinance as yf
+import pandas as pd
+from pymongo import MongoClient
+from dotenv import load_dotenv
+import os
+import time
+
+load_dotenv()
+db_password = os.getenv("DB_PASSWORD")
+if not db_password:
+    raise ValueError("DB_PASSWORD is not set in .env")
+
+MONGO_URI = f"mongodb+srv://skkucapstone:{db_password}@stock.iz5b97b.mongodb.net/?retryWrites=true&w=majority"
+client = MongoClient(MONGO_URI)
+collection = client["db"]["tickers"]
+
+def fix_ticker_format(ticker: str) -> str:
+    return ticker.replace(".", "-")
+
+def get_sp500_tickers():
+    url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+    df = pd.read_html(url)[0]  # S&P 500 테이블블
+    return df["Symbol"].tolist()
+
+def get_nasdaq_100_tickers():
+    url = "https://en.wikipedia.org/wiki/NASDAQ-100"
+    df = pd.read_html(url)[4]  # NASDAQ-100 테이블
+    return df["Ticker"].tolist()
+
+def fetch_company_name(ticker: str) -> str:
+    try:
+        info = yf.Ticker(ticker).info
+        return info.get("longName") or info.get("shortName")
+    except Exception:
+        return None
+    
+def insert_ticker(ticker: str, name: str):
+    if not name:
+        print(f"{ticker}: null")
+        return
+    collection.update_one(
+        {"ticker": ticker},
+        {"$set": {"ticker": ticker, "name": name}},
+        upsert=True
+    )
+    print(f"{ticker}: {name}")
+    
+if __name__ == "__main__":
+    sp500 = get_sp500_tickers()
+    nasdaq = get_nasdaq_100_tickers()
+    all_tickers = list(set(sp500 + nasdaq))
+    
+    for raw in all_tickers:
+        ticker = fix_ticker_format(raw)
+        name = fetch_company_name(ticker)
+        insert_ticker(ticker, name)
+        time.sleep(0.2)
+
+    print("티커 + 회사 이름 MongoDB 저장 완료")


### PR DESCRIPTION
## 주요 변경사항

1. **티커 시딩 스크립트 추가**
   - S&P 500 및 NASDAQ 100의 티커 정보를 Wikipedia에서 크롤링
   - yfinance를 통해 회사 이름까지 가져와 MongoDB에 저장
   - 검색 자동완성 기능을 위한 `ticker`, `name` 정보를 `tickers` 컬렉션에 저장

2. **/search API 구현**
   - `/search?t=검색어` 형식으로 요청 시 관련된 종목코드 또는 회사명을 최대 10개까지 반환
   - ticker와 name 필드 모두 대상으로 부분 문자열 검색 (대소문자 구분 없음)
   - 프론트엔드 자동완성 기능과 연동 가능

3. **Docker Compose 설정**
   - `docker-compose.yml`을 추가하여 백엔드 실행 및 환경 변수 관리 간소화
   - `.env` 파일을 자동으로 인식하여 MongoDB 연결 정보 주입
   - FastAPI 서버가 포트 8000에서 실행되도록 설정

## TODO

- `/stock-info` API에 실제 주가 정보 및 뉴스 정보 연동
- 자동완성 대상에 한국(KOSPI) 종목 추가 여부 검토
- `/stock-info` API에 실제 주가 예측 및 XAI 해석 모델 연동 (모델 구축 완료 시에)