### PR TITLE
refactor: rename /search API parameter from t to keyword and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,44 +7,45 @@ This project provides a simple FastAPI-based backend to fetch stock-related info
 
 1. **Landing Page**: (Front-end perspective, not an API) – A simple page with a search bar for the stock ticker.  
 2. **GET /stock-info**:  
-   - Fetches chart data, news, prediction result, and explanation in one go, based on query params:
-     - `ticker` (required)
-     - `horizon` (optional, default 7)
-     - `includeNews` (optional, boolean, default true)
-     - `includeXAI` (optional, boolean, default true)
-
-Example Request:
-```
-GET /stock-info?ticker=AAPL&horizon=7&includeNews=true&includeXAI=true
-```
-
+  - Fetches chart data, news, prediction result, and explanation in one go, based on query params:
+    - `ticker` (required)
+    - `horizon` (optional, default 7)
+    - `includeNews` (optional, boolean, default true)
+    - `includeXAI` (optional, boolean, default true)
+  ```
+  GET /stock-info?ticker=AAPL&horizon=7&includeNews=true&includeXAI=true
+  ```
+3. GET /search
+  - Autocomplete for stock tickers and company names
+  - Query parameters:
+    - keyword (required): partial string for matching ticker or name
+  ```http
+  GET /search?keyword=apple
+  ```
 
 ## 2. Project Structure
 
 ```
-myproject/
+backend/
 ├── app/
-│   ├── main.py            # FastAPI entrypoint (app 객체, 라우터 등록)
+│   ├── main.py              # FastAPI entrypoint and router registration
+│   ├── database.py          # MongoDB connection via pymongo
+│   ├── crud.py              # Logic for fetching mock data (prediction, news)
+│   ├── schemas.py           # Pydantic models for API request/response
 │   ├── routers/
-│   │   └── stock.py       # /stock-info 라우터 정의
-│   ├── database.py        # MongoDB 연결 (pymongo)
-│   ├── crud.py            # 예측/뉴스/DB 관련 로직 모음 (선택)
-│   ├── schemas.py         # Pydantic 데이터 모델 (Request/Response)
+│   │   ├── stock.py         # /stock-info endpoint
+│   │   └── search.py        # /search endpoint
 │   └── __init__.py
-├── requirements.txt       # Python 패키지 목록
-└── Dockerfile             # Docker 빌드 설정
+├── scripts/
+│   └── seed_us_stocks.py    # Seed S&P500 + NASDAQ100 tickers to MongoDB
+├── requirements.txt         # Python dependencies
+├── Dockerfile
+└── docker-compose.yml
 ```
-
-- app/main.py: FastAPI 애플리케이션을 생성하고, 라우터들을 등록합니다.
-- app/routers/stock.py: `/stock-info` 라우트를 정의합니다.
-- app/database.py: MongoDB에 연결하는 클라이언트를 설정합니다. pymongo 기반입니다.
-- app/crud.py: 예측, 뉴스, 해석 결과를 MongoDB에서 가져오거나 가공하는 로직이 들어갑니다. (현재 Mock data 사용)
-- app/schemas.py: 요청 및 응답의 데이터 구조를 정의합니다 (Pydantic 사용).
-
 
 ## 3. Setup & Run (Local)
 
-### 3.1. Create a Python virtual environment (optional, but recommended)
+### 3.1. Create virtual environment
 
 ```bash
 python -m venv venv
@@ -65,29 +66,13 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
 - The server should be available at http://localhost:8000
-- Test endpoint: http://localhost:8000/stock-info?ticker=AAPL&horizon=7&includeNews=true&includeXAI=true
+- Swagger: http://localhost:8000/docs
 
-
-## 4. Docker Build & Run
-
-### 4.1. Build Docker Image
+## 4. Docker Run (Docker Compose)
 
 ```bash
-docker build -t stockinfo:latest .
+docker-compose up -d --build
 ```
-
-### 4.2. Run the Container
-
-```bash
-docker run -d -p 8000:8000 --name stockinfo-app stockinfo:latest
-```
-
-### 4.3. Verify
-
-```bash
-curl "http://localhost:8000/stock-info?ticker=AAPL&horizon=7&includeNews=true&includeXAI=true"
-```
-
 
 ## 5. Contributor
 

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -6,12 +6,12 @@ router = APIRouter()
 
 # GET /search?t=XXX
 @router.get("/search")
-def search_tickers(t: str = Query(..., description="검색 키워드")):
+def search_tickers(keyword: str = Query(..., description="검색 키워드")):
     """
     종목 코드(ticker) 또는 회사 이름(name)으로 자동완성 검색
-    - Query param: t
+    - Query param: keyword
     """
-    regex = {"$regex": t, "$options": "i"}
+    regex = {"$regex": keyword, "$options": "i"}
     results = db["tickers"].find(
         { "$or": [ { "ticker": regex }, { "name": regex } ] },
         { "_id": 0 }


### PR DESCRIPTION
## 주요 변경사항

- `/search` API의 쿼리 파라미터명을 `t` → `keyword` 로 변경
- `README.md`의 관련 설명 변경