### PR TITLE
Feat: replace chart mock data with real data using yfinance

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -1,13 +1,28 @@
 # app/crud.py
-
 from typing import List, Dict
+import yfinance as yf
 
 # 주가 데이터 조회 (mock)
 def get_chart_data(ticker: str) -> List[Dict]:
-    return [
-        {"date": "2025-04-01", "open": 170.2, "close": 172.5},
-        {"date": "2025-04-02", "open": 172.5, "close": 173.1},
-    ]
+    ticker_data = yf.Ticker(ticker)
+    data = ticker_data.history(period="1mo")
+    if not data.empty:
+        # 소수점 2자리로 반올림
+        data = data.round(2)
+        chart_data = [
+            {
+                "date": str(date.date()),
+                "open": row["Open"],
+                "close": row["Close"],
+                "high": row["High"],
+                "low": row["Low"],
+                # "volume": row["Volume"],
+            }
+            for date, row in data.iterrows()
+        ]
+        return chart_data
+    else:
+        return []
 
 # 뉴스 요약 데이터 (mock or 실제 RAG 대체 가능)
 def get_recent_news(ticker: str) -> List[Dict]:

--- a/app/routers/stock.py
+++ b/app/routers/stock.py
@@ -26,7 +26,7 @@ def get_stock_info(
     if not db["tickers"].find_one({"ticker": ticker}):
         raise HTTPException(status_code=404, detail="해당 티커 정보를 찾을 수 없습니다.")
     
-    # 차트 데이터 (Mock)
+    # 차트 데이터
     chart_data = get_chart_data(ticker)
 
     # 뉴스 데이터 (Mock)

--- a/app/routers/stock.py
+++ b/app/routers/stock.py
@@ -1,6 +1,7 @@
 # app/routers/stock.py
 from fastapi import APIRouter, Query, HTTPException
 from ..crud import *
+from ..database import db
 from ..schemas import StockInfoResponse, StockInfoWrapper
 
 router = APIRouter()
@@ -21,11 +22,10 @@ def get_stock_info(
     - includeXAI: 예측 결과 해석 포함 여부
     """
 
-    # 유효한 티커인지 확인 (Mock)
-    valid_tickers = ["AAPL", "MSFT", "GOOG"]
-    if ticker not in valid_tickers:
+    # 유효한 티커인지 MongoDB에서 확인
+    if not db["tickers"].find_one({"ticker": ticker}):
         raise HTTPException(status_code=404, detail="해당 티커 정보를 찾을 수 없습니다.")
-
+    
     # 차트 데이터 (Mock)
     chart_data = get_chart_data(ticker)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -5,6 +5,8 @@ class ChartDataItem(BaseModel):
     date: str
     open: float
     close: float
+    high: float
+    low: float
 
 class NewsItem(BaseModel):
     title: str


### PR DESCRIPTION
## 주요 변경 사항

- `/stock-info` API의 차트 데이터(`chartData`)를 기존 Mock에서 실제 주가 데이터로 변경하였습니다.
- `yfinance` 라이브러리를 사용하여 해당 ticker의 최근 1개월치 데이터를 가져오며, `open`, `close`, `high`, `low` 값을 포함합니다.
- 이를 반영하여 `schemas.py`의 `ChartDataItem` 모델도 필드를 추가하여 구조를 맞췄습니다.
- ticker 유효성은 MongoDB의 `tickers` 컬렉션에서 확인하는 방식으로 동작합니다.

## TODO

- 뉴스 요약 부분도 실제 외부 API 또는 요약 모델 기반으로 교체
- 예측 및 XAI 결과를 실제 모델로 연동
