### PR TITLE
feat: allow /search to return all tickers when keyword is omitted

### DIFF
--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,19 +1,23 @@
 # app/routers/search.py
 from fastapi import APIRouter, Query
+from typing import Optional
 from ..database import db
 
 router = APIRouter()
 
 # GET /search?t=XXX
 @router.get("/search")
-def search_tickers(keyword: str = Query(..., description="검색 키워드")):
+def search_tickers(keyword: Optional[str] = Query(None, description="검색 키워드 (none: all)")):
     """
     종목 코드(ticker) 또는 회사 이름(name)으로 자동완성 검색
     - Query param: keyword
     """
-    regex = {"$regex": keyword, "$options": "i"}
-    results = db["tickers"].find(
-        { "$or": [ { "ticker": regex }, { "name": regex } ] },
-        { "_id": 0 }
-    ).limit(10)
+    if keyword:
+        regex = {"$regex": keyword, "$options": "i"}
+        results = db["tickers"].find(
+            { "$or": [ { "ticker": regex }, { "name": regex } ] },
+            { "_id": 0 }
+        ).limit(10)
+    else:
+        results = db["tickers"].find({}, { "_id": 0 })
     return list(results)


### PR DESCRIPTION
## 주요 변경 사항

- `/search` API의 `keyword` 파라미터를 선택적으로 변경하였습니다 (`Optional`).
- 쿼리 파라미터가 없는 경우에는 MongoDB의 `tickers` 컬렉션에서 전체 종목을 조회하도록 동작합니다.
