### PR TITLE
hotfix: allow all origins in CORS for frontend development

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,20 @@
 # app/main.py
 from fastapi import FastAPI
 from .routers import stock, search
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
 app.include_router(stock.router)    # /stock-info
 app.include_router(search.router)   # /search 자동완성 API 추가
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # TODO: Change to frontend URL in production (all origins for now)
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
TODO: 현재는 편의 상 모든 URL을 허용했지만 (allow_origins=["*"]) 추후 배포시에는 변경 필요