### PR TITLE
feat: return popular ticker list when keyword is missing in /search API

### DIFF
--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,19 +1,23 @@
 # app/routers/search.py
 from fastapi import APIRouter, Query
+from typing import Optional
 from ..database import db
 
 router = APIRouter()
 
 # GET /search?t=XXX
 @router.get("/search")
-def search_tickers(keyword: str = Query(..., description="검색 키워드")):
+def search_tickers(keyword: Optional[str] = Query(None, description="검색 키워드 (none: all)")):
     """
     종목 코드(ticker) 또는 회사 이름(name)으로 자동완성 검색
     - Query param: keyword
     """
-    regex = {"$regex": keyword, "$options": "i"}
-    results = db["tickers"].find(
-        { "$or": [ { "ticker": regex }, { "name": regex } ] },
-        { "_id": 0 }
-    ).limit(10)
+    if keyword:
+        regex = {"$regex": keyword, "$options": "i"}
+        results = db["tickers"].find(
+            { "$or": [ { "ticker": regex }, { "name": regex } ] },
+            { "_id": 0 }
+        ).limit(10)
+    else:
+        results = db["tickers"].find({}, { "_id": 0 })
     return list(results)

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -3,6 +3,15 @@ from fastapi import APIRouter, Query
 from typing import Optional
 from ..database import db
 
+# S&P 500 시가총액 상위 + 검색량 많은 종목 + 대표 섹터별 종목 조합 50개
+POPULAR_TICKERS = [
+    "AAPL", "MSFT", "GOOG", "AMZN", "TSLA", "NVDA", "META", "NFLX", "BRK-B",
+    "JPM", "V", "JNJ", "UNH", "PG", "MA", "HD", "DIS", "ADBE", "PYPL", "BAC",
+    "XOM", "INTC", "T", "KO", "PFE", "WMT", "CRM", "CVX", "PEP", "MRK", "ABT",
+    "ORCL", "QCOM", "LLY", "CSCO", "MCD", "TMO", "COST", "NKE", "DHR", "ACN",
+    "AVGO", "TXN", "AMD", "SBUX", "AMAT", "INTU", "GE", "HON", "ISRG", "BA"
+]
+
 router = APIRouter()
 
 # GET /search?t=XXX
@@ -19,5 +28,8 @@ def search_tickers(keyword: Optional[str] = Query(None, description="검색 키�
             { "_id": 0 }
         ).limit(10)
     else:
-        results = db["tickers"].find({}, { "_id": 0 })
+        results = db["tickers"].find(
+            { "ticker": { "$in": POPULAR_TICKERS } },
+            { "_id": 0 }
+        )
     return list(results)


### PR DESCRIPTION
## 주요 변경 사항

- `/search` API에서 `keyword`가 주어지지 않은 경우, MongoDB에 저장된 전체 종목을 모두 반환하지 않고, **인기 종목 50개만 반환**하도록 변경했습니다.
- 하드코딩된 `POPULAR_TICKERS` 리스트는 시가총액 상위 종목, 검색량 많은 종목, 대표 섹터 종목을 기준으로 구성되었습니다.