### PR TITLE
feat: Add US/KOSPI stock news fetching and update /stock-info API

### DIFF
--- a/app/routers/stock.py
+++ b/app/routers/stock.py
@@ -30,12 +30,11 @@ def get_stock_info(
     else:
         raise HTTPException(status_code=404, detail="해당 티커 정보를 찾을 수 없습니다.")
     
-    
     # 차트 데이터
     chart_data = get_chart_data(ticker, market)
 
-    # 뉴스 데이터 (Mock)
-    news_data = get_recent_news(ticker) if includeNews else []
+    # 뉴스 데이터
+    news_data = get_recent_news(ticker, market) if includeNews else []
 
     # 예측 결과 (Mock)
     prediction = run_prediction(ticker, horizon)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -11,7 +11,9 @@ class ChartDataItem(BaseModel):
 class NewsItem(BaseModel):
     title: str
     summary: str
-    sentiment: str
+    link: str
+    pubDate: str    # 뉴스 발행 시간
+    provider: str   # 뉴스 제공자
 
 class PredictionData(BaseModel):
     horizon: int


### PR DESCRIPTION
## 주요 변경사항
- yfinance를 활용하여 미국 주식(`ticker`) 뉴스 데이터 조회 기능 구현
- 한국 주식(`ticker + .KS`)에 대해서도 뉴스 조회 시도 및 fallback 처리
- 뉴스 데이터 모델(`NewsItem`) 수정
  - 추가 필드: `link`, `pubDate`, `provider`
  - 제거 필드: `sentiment`
- `/stock-info` API에서 뉴스 데이터 반환 구조 수정
  - 뉴스 포함 여부(includeNews)에 따라 yfinance 뉴스 동적 호출
- Swagger 문서 정상 반영 및 Response 스키마 정합성 검증 완료

## 테스트
- `/stock-info` API 호출 시 미국 및 한국 주식 뉴스 10건 이내로 정상 조회
- 뉴스 데이터의 각 항목(`title`, `summary`, `link`, `pubDate`, `provider`)이 정상 반환되는지 확인
- Pydantic 모델 Validation 에러 없이 정상 응답

## 기타
- 현재 한국 주식 뉴스는 글로벌 뉴스(영문)만 조회 가능
- 향후 한국어 뉴스 크롤링 추가 예정