### PR TITLE
fix: prevent duplicate insertions by handling race conditions in prediction and explanation

### DIFF
--- a/app/crud/explanation.py
+++ b/app/crud/explanation.py
@@ -57,8 +57,11 @@ def generate_explanation(
                 "token_scores": existing.get_token_score()
             }
 
-        # API URL 확인 (XAI API)
-        api_url = os.getenv("NGROK_API_URL") + "explain"
+        # Build API URL
+        base_url = os.getenv("NGROK_API_URL", "")
+        if not base_url.endswith("/"):
+            base_url += "/"
+        api_url = base_url + "explain"
         if not api_url:
             return {"predicted_date": pred_date, "tokens": [], "token_scores": []}
 

--- a/app/crud/explanation.py
+++ b/app/crud/explanation.py
@@ -9,6 +9,7 @@ import requests
 import json
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
 from db.session import SessionLocal
 from db.models.ticker import Ticker
@@ -72,27 +73,49 @@ def generate_explanation(
                 api_url,
                 params={"ticker": fetch_code, "horizon_days": horizon},
                 headers={"ngrok-skip-browser-warning": "true"},
-                timeout=30
+                timeout=60
             )
             resp.raise_for_status()
             payload = resp.json()
         except Exception as e:
-            print("XAI API 안 띄웠거나 주소 잘못됨:", e)
+            print("XAI API error:", e)
             return {"predicted_date": pred_date, "tokens": [], "token_scores": []}
 
         tokens = payload.get("token_list", [])
         token_scores = payload.get("token_score_list", [])
 
-        # DB에 저장 (직렬화)
-        explain = Explanation(
-            ticker_id=ticker.id,
-            predicted_date=pred_date,
-            horizon_days=horizon,
-        )
-        explain.set_token(tokens)
-        explain.set_token_score(token_scores)
-        db.add(explain)
-        db.commit()
+        # Attempt to insert into DB
+        try:
+            explain = Explanation(
+                ticker_id=ticker.id,
+                predicted_date=pred_date,
+                horizon_days=horizon,
+            )
+            explain.set_token(tokens)
+            explain.set_token_score(token_scores)
+            db.add(explain)
+            db.commit()
+        except IntegrityError:
+            # Race condition: another process inserted same record
+            db.rollback()
+            
+            existing = db.execute(
+                select(Explanation).where(
+                    Explanation.ticker_id == ticker.id,
+                    Explanation.horizon_days == horizon,
+                    Explanation.predicted_date == pred_date
+                )
+            ).scalar_one_or_none()
+
+            if existing:
+                return {
+                    "predicted_date": pred_date,
+                    "tokens": existing.get_token(),
+                    "token_scores": existing.get_token_score()
+                }
+
+            # Fallback if still not found
+            return {"predicted_date": pred_date, "tokens": [], "token_scores": []}
 
         return {
             "predicted_date": pred_date,

--- a/app/crud/prediction.py
+++ b/app/crud/prediction.py
@@ -53,8 +53,12 @@ def run_prediction(
         if existing:
             return {"predicted_date": pred_date.isoformat(), "result": existing.prediction_result}
 
-        # API URL 확인
-        api_url = os.getenv("NGROK_API_URL") + "predict"
+        # Build API URL
+        base_url = os.getenv("NGROK_API_URL", "")
+        if not base_url.endswith("/"):
+            base_url += "/"
+        api_url = base_url + "predict"
+        
         if not api_url:
             return {"predicted_date": pred_date.isoformat(), "result": 0.0}
 

--- a/app/crud/prediction.py
+++ b/app/crud/prediction.py
@@ -8,6 +8,7 @@ import os
 import requests
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 
 from db.session import SessionLocal
 from db.models.ticker import Ticker
@@ -70,7 +71,7 @@ def run_prediction(
                 api_url,
                 params={"ticker": fetch_code, "horizon_days": horizon},
                 headers={"ngrok-skip-browser-warning": "true"},
-                timeout=30
+                timeout=60
             )
             resp.raise_for_status()
             payload = resp.json()
@@ -78,19 +79,34 @@ def run_prediction(
             print("XAI API 안 띄웠거나 주소 잘못됨:", e)
             return {"predicted_date": pred_date.isoformat(), "result": 0.0}
 
-        result = payload.get("prediction_result", "")
+        result = payload.get("prediction_result", 0.0)
 
-        # DB에 저장
-        pred = Prediction(
-            ticker_id=ticker.id,
-            predicted_date=pred_date,
-            horizon_days=horizon,
-            prediction_result=result
-        )
-        db.add(pred)
-        db.commit()
+        # Insert into DB with exception safety
+        try:
+            pred = Prediction(
+                ticker_id=ticker.id,
+                predicted_date=pred_date,
+                horizon_days=horizon,
+                prediction_result=result
+            )
+            db.add(pred)
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            existing = db.execute(
+                select(Prediction)
+                .where(
+                    Prediction.ticker_id == ticker.id,
+                    Prediction.horizon_days == horizon,
+                    Prediction.predicted_date == pred_date
+                )
+            ).scalar_one_or_none()
+
+            if existing:
+                return {"predicted_date": pred_date.isoformat(), "result": existing.prediction_result}
+            return {"predicted_date": pred_date.isoformat(), "result": 0.0}
 
         return {
-            "predicted_date": pred_date.isoformat(), 
+            "predicted_date": pred_date.isoformat(),
             "result": result
         }

--- a/db/init_db.py
+++ b/db/init_db.py
@@ -7,6 +7,16 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from db.session import engine, Base
 from db.models import explanation, ticker, chart_data, prediction, news
 
+from db.seeds.seed_kospi_tickers import seed_kospi_tickers
+from db.seeds.seed_us_tickers import seed_us_tickers
+
 if __name__ == "__main__":
+    Base.metadata.drop_all(bind=engine)
+    print("Dropped all tables.")
+    
     Base.metadata.create_all(bind=engine)
     print("All tables created.")
+
+    seed_kospi_tickers()
+    seed_us_tickers()
+    print("All seed data inserted.")

--- a/db/models/explanation.py
+++ b/db/models/explanation.py
@@ -1,5 +1,5 @@
 # db/models/explaination.py
-from sqlalchemy import Column, Integer, String, Date, ForeignKey, Float, Text
+from sqlalchemy import Column, Integer, Date, ForeignKey, Text, UniqueConstraint
 import json
 from ..session import Base
 
@@ -10,8 +10,12 @@ class Explanation(Base):
     ticker_id = Column(Integer, ForeignKey("ticker.id"), nullable=False)
     predicted_date = Column(Date, nullable=False)
     horizon_days = Column(Integer, nullable=False)
-    token = Column(Text)       # JSON 직렬화된 string
-    token_score = Column(Text) # JSON 직렬화된 string
+    token = Column(Text)
+    token_score = Column(Text)
+
+    __table_args__ = (
+        UniqueConstraint("ticker_id", "predicted_date", "horizon_days", name="uq_explanation_main"),
+    )
 
     def set_token(self, token_list):
         self.token = json.dumps(token_list)

--- a/db/models/prediction.py
+++ b/db/models/prediction.py
@@ -1,5 +1,5 @@
 # db/models/prediction.py
-from sqlalchemy import Column, Integer, Date, ForeignKey, Float
+from sqlalchemy import Column, Integer, Date, ForeignKey, Float, UniqueConstraint
 from ..session import Base
 
 class Prediction(Base):
@@ -10,3 +10,7 @@ class Prediction(Base):
     predicted_date = Column(Date, nullable=False)
     horizon_days = Column(Integer, nullable=False)
     prediction_result = Column(Float)
+
+    __table_args__ = (
+        UniqueConstraint("ticker_id", "predicted_date", "horizon_days", name="uq_prediction_main"),
+    )

--- a/db/models/ticker.py
+++ b/db/models/ticker.py
@@ -8,4 +8,4 @@ class Ticker(Base):
     id = Column(Integer, primary_key=True, index=True)
     ticker_code = Column(String(20), unique=True, nullable=False)
     company_name = Column(String(100))
-    market = Column(String, nullable=False)
+    market = Column(String(10), nullable=False)

--- a/db/seeds/seed_kospi_tickers.py
+++ b/db/seeds/seed_kospi_tickers.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from db.session import SessionLocal
 from db.models.ticker import Ticker
 
-def get_kospi_tickers(limit=50):
+def get_kospi_tickers(limit=100):
     kospi = fdr.StockListing('KOSPI')
     top = kospi.sort_values(by='Marcap', ascending=False).head(limit)
     return top[['Code', 'Name']].reset_index(drop=True)

--- a/db/seeds/seed_us_tickers.py
+++ b/db/seeds/seed_us_tickers.py
@@ -43,7 +43,7 @@ def insert_ticker(db: Session, ticker: str, name: str):
     else:
         db.add(Ticker(ticker_code=ticker, company_name=name, market="US"))
     db.commit()
-    print(f"{ticker}: {name}")
+    # print(f"{ticker}: {name}")
 
 def seed_us_tickers():
     session = SessionLocal()
@@ -56,7 +56,7 @@ def seed_us_tickers():
         ticker = fix_ticker_format(raw)
         name = fetch_company_name(ticker)
         insert_ticker(session, ticker, name)
-        time.sleep(0.2)
+        time.sleep(0.05)
 
     session.close()
     print("US tickers inserted into MySQL successfully!")


### PR DESCRIPTION
## 주요 변경 사항

- `/stock-info/pred`와 `/stock-info/exp` 호출 시 동시에 여러 요청이 들어올 경우 발생할 수 있는 race condition을 방지하였습니다.
- `Prediction` 및 `Explanation` 테이블은 `(ticker_id, predicted_date, horizon_days)` 조합에 대해 UNIQUE 제약 조건이 적용되어 있으므로, 중복 insert 시 `IntegrityError`가 발생할 수 있었습니다. 
- 이를 try-except로 안전하게 처리하고, rollback 후 캐시 재조회 로직을 추가하여 안정적인 캐싱 동작을 구현했습니다.
- 외부 API 호출 → DB 저장 과정에서 생기는 경합 문제를 해결하여, 실시간 요청이 많을 때도 정상 응답을 보장합니다.

## 기타

- NGROK URL 사용 시 슬래시 누락 방지를 위한 처리도 추가하였습니다.
